### PR TITLE
Support gNMI SET RPC

### DIFF
--- a/cmd/gnmi/run.go
+++ b/cmd/gnmi/run.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"reflect"
 
 	"github.com/openconfig/ygot/ygot"
@@ -14,18 +15,36 @@ import (
 
 var (
 	current *model.PacketTransponder
-	gitdir  = "/etc/oopt"
+	git_dir = "/etc/oopt"
 )
 
 const (
 	CONFIG_FILE = "config.json"
 )
 
+func callback(newConfig ygot.ValidatedGoStruct) error {
+	buf, err := ygot.EmitJSON(newConfig, &ygot.EmitJSONConfig{
+		Format: ygot.RFC7951,
+	})
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	file, err := os.Create(fmt.Sprintf("%s/%s", git_dir, CONFIG_FILE))
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	defer file.Close()
+	file.Write(([]byte)(buf))
+	file.Write([]byte("\n"))
+
+	return nil
+}
+
 func main() {
 	port := flag.Int64("port", 10164, "Listen port")
 	flag.Parse()
 
-	data, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", gitdir, CONFIG_FILE))
+	data, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", git_dir, CONFIG_FILE))
 	if err != nil {
 		panic(fmt.Sprintf("open: %v", err))
 	}
@@ -34,21 +53,17 @@ func main() {
 
 	servermodel := oopt.NewModel(
 		oopt.ModelData,
-		reflect.TypeOf((*model.Device)(nil)),
-		model.SchemaTree["Device"],
+		reflect.TypeOf((*model.PacketTransponder)(nil)),
+		model.SchemaTree["PacketTransponder"],
 		model.Unmarshal,
 		model.ΛEnum,
 	)
 
-	d := &model.Device{
-		PacketTransponder: current,
-	}
-
-	if err = d.Validate(); err != nil {
+	if err = current.Validate(); err != nil {
 		panic(fmt.Sprintf("validation failed: %v", err))
 	}
 
-	json, err := ygot.EmitJSON(d, &ygot.EmitJSONConfig{
+	json, err := ygot.EmitJSON(current, &ygot.EmitJSONConfig{
 		Format: ygot.RFC7951,
 		Indent: "  ",
 		RFC7951Config: &ygot.RFC7951JSONConfig{
@@ -59,7 +74,7 @@ func main() {
 		panic(fmt.Sprintf("EmitJSON failed: %v", err))
 	}
 
-	srv, err := oopt.NewServer(servermodel, []byte(json), *port, nil)
+	srv, err := oopt.NewServer(servermodel, []byte(json), *port, callback, nil)
 	if err != nil {
 		panic(fmt.Sprintf("NewServer() failed: %v", err))
 	}

--- a/cmd/gnmi_set/gnmi_set.go
+++ b/cmd/gnmi_set/gnmi_set.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 Nippon Telegraph and Telephone Corporation
+Copyright 2017 Google Inc.
+
+Derived from google/gnxi | https://github.com/google/gnxi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Binary gnmi_set performs a set request against a gNMI target with the specified config file.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"github.com/google/gnxi/utils"
+	"github.com/google/gnxi/utils/xpath"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	return "my string representation"
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+var (
+	deleteOpt  arrayFlags
+	replaceOpt arrayFlags
+	updateOpt  arrayFlags
+	targetAddr = flag.String("target_addr", "localhost:10161", "The target address in the format of host:port")
+	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
+	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
+)
+
+func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
+	var pbUpdateList []*pb.Update
+	for _, item := range pathValuePairs {
+		pathValuePair := strings.SplitN(item, ":", 2)
+		// TODO (leguo): check if any path attribute contains ':'
+		if len(pathValuePair) != 2 || len(pathValuePair[1]) == 0 {
+			log.Exitf("invalid path-value pair: %v", item)
+		}
+		pbPath, err := xpath.ToGNMIPath(pathValuePair[0])
+		if err != nil {
+			log.Exitf("error in parsing xpath %q to gnmi path", pathValuePair[0])
+		}
+		var pbVal *pb.TypedValue
+		if pathValuePair[1][0] == '@' {
+			jsonFile := pathValuePair[1][1:]
+			jsonConfig, err := ioutil.ReadFile(jsonFile)
+			if err != nil {
+				log.Exitf("cannot read data from file %v", jsonFile)
+			}
+			jsonConfig = bytes.Trim(jsonConfig, " \r\n\t")
+			pbVal = &pb.TypedValue{
+				Value: &pb.TypedValue_JsonIetfVal{
+					JsonIetfVal: jsonConfig,
+				},
+			}
+		} else {
+			if strVal, err := strconv.Unquote(pathValuePair[1]); err == nil {
+				pbVal = &pb.TypedValue{
+					Value: &pb.TypedValue_StringVal{
+						StringVal: strVal,
+					},
+				}
+			} else {
+				if intVal, err := strconv.ParseInt(pathValuePair[1], 10, 64); err == nil {
+					pbVal = &pb.TypedValue{
+						Value: &pb.TypedValue_IntVal{
+							IntVal: intVal,
+						},
+					}
+				} else if floatVal, err := strconv.ParseFloat(pathValuePair[1], 32); err == nil {
+					pbVal = &pb.TypedValue{
+						Value: &pb.TypedValue_FloatVal{
+							FloatVal: float32(floatVal),
+						},
+					}
+				} else if boolVal, err := strconv.ParseBool(pathValuePair[1]); err == nil {
+					pbVal = &pb.TypedValue{
+						Value: &pb.TypedValue_BoolVal{
+							BoolVal: boolVal,
+						},
+					}
+				} else {
+					pbVal = &pb.TypedValue{
+						Value: &pb.TypedValue_StringVal{
+							StringVal: pathValuePair[1],
+						},
+					}
+				}
+			}
+		}
+		pbUpdateList = append(pbUpdateList, &pb.Update{Path: pbPath, Val: pbVal})
+	}
+	return pbUpdateList
+}
+
+func main() {
+	flag.Var(&deleteOpt, "delete", "xpath to be deleted.")
+	flag.Var(&replaceOpt, "replace", "xpath:value pair to be replaced. Value can be numeric, boolean, string, or IETF JSON file (. starts with '@').")
+	flag.Var(&updateOpt, "update", "xpath:value pair to be updated. Value can be numeric, boolean, string, or IETF JSON file (. starts with '@').")
+	flag.Parse()
+
+	conn, err := grpc.Dial(*targetAddr, grpc.WithInsecure())
+	if err != nil {
+		log.Exitf("Dialing to %q failed: %v", *targetAddr, err)
+	}
+	defer conn.Close()
+
+	var deleteList []*pb.Path
+	for _, xPath := range deleteOpt {
+		pbPath, err := xpath.ToGNMIPath(xPath)
+		if err != nil {
+			log.Exitf("error in parsing xpath %q to gnmi path", xPath)
+		}
+		deleteList = append(deleteList, pbPath)
+	}
+	replaceList := buildPbUpdateList(replaceOpt)
+	updateList := buildPbUpdateList(updateOpt)
+
+	setRequest := &pb.SetRequest{
+		Delete:  deleteList,
+		Replace: replaceList,
+		Update:  updateList,
+	}
+
+	fmt.Println("== setRequest:")
+	utils.PrintProto(setRequest)
+
+	cli := pb.NewGNMIClient(conn)
+	setResponse, err := cli.Set(context.Background(), setRequest)
+	if err != nil {
+		log.Exitf("Set failed: %v", err)
+	}
+
+	fmt.Println("== getResponse:")
+	utils.PrintProto(setResponse)
+}

--- a/pkg/gnmi/model.go
+++ b/pkg/gnmi/model.go
@@ -1,4 +1,4 @@
-/* 
+/*
 Copyright 2018 Nippon Telegraph and Telephone Corporation
 Copyright 2017 Google Inc.
 

--- a/pkg/gnmi/server.go
+++ b/pkg/gnmi/server.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -27,7 +28,11 @@ import (
 	cpb "google.golang.org/genproto/googleapis/rpc/code"
 )
 
+// ConfigCallback is the signature of the function to apply a validated config to the physical device.
+type ConfigCallback func(ygot.ValidatedGoStruct) error
+
 var (
+	pbRootPath         = &pb.Path{}
 	supportedEncodings = []pb.Encoding{pb.Encoding_JSON, pb.Encoding_JSON_IETF}
 	ModelData          = []*pb.ModelData{{
 		Name:         "packet-transport",
@@ -40,16 +45,17 @@ var (
 // via Subscribe or Get will receive a stream of updates based on the requested
 // path. Set request is processed by server too.
 type Server struct {
-	s      *grpc.Server
-	lis    net.Listener
-	port   int64
-	config ygot.ValidatedGoStruct
-	cMu    sync.Mutex
-	model  *Model
+	s        *grpc.Server
+	lis      net.Listener
+	port     int64
+	config   ygot.ValidatedGoStruct
+	cMu      sync.Mutex
+	model    *Model
+	callback ConfigCallback
 }
 
 // NewServer returns an initialized server.
-func NewServer(model *Model, config []byte, port int64, opts []grpc.ServerOption) (*Server, error) {
+func NewServer(model *Model, config []byte, port int64, callback ConfigCallback, opts []grpc.ServerOption) (*Server, error) {
 	rootStruct, err := model.NewConfigStruct(config)
 	if err != nil {
 		return nil, err
@@ -59,10 +65,11 @@ func NewServer(model *Model, config []byte, port int64, opts []grpc.ServerOption
 	reflection.Register(s)
 
 	srv := &Server{
-		s:      s,
-		port:   port,
-		config: rootStruct,
-		model:  model,
+		s:        s,
+		port:     port,
+		config:   rootStruct,
+		model:    model,
+		callback: callback,
 	}
 	if srv.port < 0 {
 		srv.port = 0
@@ -94,6 +101,18 @@ func (srv *Server) Address() string {
 // Port returns the port the server is listening to.
 func (srv *Server) Port() int64 {
 	return srv.port
+}
+
+func (srv *Server) toGoStruct(jsonTree map[string]interface{}) (ygot.ValidatedGoStruct, error) {
+	jsonDump, err := json.Marshal(jsonTree)
+	if err != nil {
+		return nil, fmt.Errorf("error in marshaling IETF JSON tree to bytes: %v", err)
+	}
+	goStruct, err := srv.model.NewConfigStruct(jsonDump)
+	if err != nil {
+		return nil, fmt.Errorf("error in creating config struct from IETF JSON data: %v", err)
+	}
+	return goStruct, nil
 }
 
 // getGNMIServiceVersion returns a pointer to the gNMI service version string.
@@ -145,6 +164,105 @@ func isNil(i interface{}) bool {
 	}
 }
 
+// deleteKeyedListEntry deletes the keyed list entry from node that matches the
+// path elem. If the entry is the only one in keyed list, deletes the entire
+// list. If the entry is found and deleted, the function returns true. If it is
+// not found, the function returns false.
+func deleteKeyedListEntry(node map[string]interface{}, elem *pb.PathElem) bool {
+	curNode, ok := node[elem.Name]
+	if !ok {
+		return false
+	}
+
+	keyedList, ok := curNode.([]interface{})
+	if !ok {
+		return false
+	}
+	for i, n := range keyedList {
+		m, ok := n.(map[string]interface{})
+		if !ok {
+			fmt.Errorf("expect map[string]interface{} for a keyed list entry, got %T", n)
+			return false
+		}
+		keyMatching := true
+		for k, v := range elem.Key {
+			attrVal, ok := m[k]
+			if !ok {
+				return false
+			}
+			if v != fmt.Sprintf("%v", attrVal) {
+				keyMatching = false
+				break
+			}
+		}
+		if keyMatching {
+			listLen := len(keyedList)
+			if listLen == 1 {
+				delete(node, elem.Name)
+				return true
+			}
+			keyedList[i] = keyedList[listLen-1]
+			node[elem.Name] = keyedList[0 : listLen-1]
+			return true
+		}
+	}
+	return false
+}
+
+// setPathWithAttribute replaces or updates a child node of curNode in the IETF
+// JSON config tree, where the child node is indexed by pathElem with attribute.
+// The function returns grpc status error if unsuccessful.
+func setPathWithAttribute(op pb.UpdateResult_Operation, curNode map[string]interface{}, pathElem *pb.PathElem, nodeVal interface{}) error {
+	nodeValAsTree, ok := nodeVal.(map[string]interface{})
+	if !ok {
+		return status.Errorf(codes.InvalidArgument, "expect nodeVal is a json node of map[string]interface{}, received %T", nodeVal)
+	}
+	m := getKeyedListEntry(curNode, pathElem, true)
+	if m == nil {
+		return status.Errorf(codes.NotFound, "path elem not found: %v", pathElem)
+	}
+	if op == pb.UpdateResult_REPLACE {
+		for k := range m {
+			delete(m, k)
+		}
+	}
+	for attrKey, attrVal := range pathElem.GetKey() {
+		m[attrKey] = attrVal
+		if asNum, err := strconv.ParseFloat(attrVal, 64); err == nil {
+			m[attrKey] = asNum
+		}
+		for k, v := range nodeValAsTree {
+			if k == attrKey && fmt.Sprintf("%v", v) != attrVal {
+				return status.Errorf(codes.InvalidArgument, "invalid config data: %v is a path attribute", k)
+			}
+		}
+	}
+	for k, v := range nodeValAsTree {
+		m[k] = v
+	}
+	return nil
+}
+
+// setPathWithoutAttribute replaces or updates a child node of curNode in the
+// IETF config tree, where the child node is indexed by pathElem without
+// attribute. The function returns grpc status error if unsuccessful.
+func setPathWithoutAttribute(op pb.UpdateResult_Operation, curNode map[string]interface{}, pathElem *pb.PathElem, nodeVal interface{}) error {
+	target, hasElem := curNode[pathElem.Name]
+	nodeValAsTree, nodeValIsTree := nodeVal.(map[string]interface{})
+	if op == pb.UpdateResult_REPLACE || !hasElem || !nodeValIsTree {
+		curNode[pathElem.Name] = nodeVal
+		return nil
+	}
+	targetAsTree, ok := target.(map[string]interface{})
+	if !ok {
+		return status.Errorf(codes.Internal, "error in setting path: expect map[string]interface{} to update, got %T", target)
+	}
+	for k, v := range nodeValAsTree {
+		targetAsTree[k] = v
+	}
+	return nil
+}
+
 // checkEncodingAndModel checks whether encoding and models are supported by the server. Return error if anything is unsupported.
 func (srv *Server) checkEncodingAndModel(encoding pb.Encoding, models []*pb.ModelData) error {
 	hasSupportedEncoding := false
@@ -158,6 +276,157 @@ func (srv *Server) checkEncodingAndModel(encoding pb.Encoding, models []*pb.Mode
 		return fmt.Errorf("unsupported encoding: %s", pb.Encoding_name[int32(encoding)])
 	}
 	return nil
+}
+
+// doDelete deletes the path from the json tree if the path exists. If success,
+// it calls the callback function to apply the change to the device hardware.
+func (srv *Server) doDelete(jsonTree map[string]interface{}, prefix, path *pb.Path) (*pb.UpdateResult, error) {
+	var curNode interface{} = jsonTree
+	pathDeleted := false
+	fullPath := gnmiFullPath(prefix, path)
+	schema := srv.model.schemaTreeRoot
+	for i, elem := range fullPath.Elem { // Delete sub-tree or leaf node.
+		node, ok := curNode.(map[string]interface{})
+		if !ok {
+			break
+		}
+
+		// Delete node
+		if i == len(fullPath.Elem)-1 {
+			if elem.GetKey() == nil {
+				delete(node, elem.Name)
+				pathDeleted = true
+				break
+			}
+			pathDeleted = deleteKeyedListEntry(node, elem)
+			break
+		}
+
+		if curNode, schema = getChildNode(node, schema, elem, false); curNode == nil {
+			break
+		}
+	}
+	if reflect.DeepEqual(fullPath, pbRootPath) { // Delete root
+		for k := range jsonTree {
+			delete(jsonTree, k)
+		}
+	}
+
+	// Apply the validated operation to the config tree and device.
+	if pathDeleted {
+		newConfig, err := srv.toGoStruct(jsonTree)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		if srv.callback != nil {
+			if applyErr := srv.callback(newConfig); applyErr != nil {
+				if rollbackErr := srv.callback(srv.config); rollbackErr != nil {
+					return nil, status.Errorf(codes.Internal, "error in rollback the failed operation (%v): %v", applyErr, rollbackErr)
+				}
+				return nil, status.Errorf(codes.Aborted, "error in applying operation to device: %v", applyErr)
+			}
+		}
+	}
+	return &pb.UpdateResult{
+		Path: path,
+		Op:   pb.UpdateResult_DELETE,
+	}, nil
+}
+
+// doReplaceOrUpdate validates the replace or update operation to be applied to
+// the device, modifies the json tree of the config struct, then calls the
+// callback function to apply the operation to the device hardware.
+func (srv *Server) doReplaceOrUpdate(jsonTree map[string]interface{}, op pb.UpdateResult_Operation, prefix, path *pb.Path, val *pb.TypedValue) (*pb.UpdateResult, error) {
+	// Validate the operation.
+	fullPath := gnmiFullPath(prefix, path)
+	emptyNode, stat := ygotutils.NewNode(srv.model.structRootType, fullPath)
+	if stat.GetCode() != int32(cpb.Code_OK) {
+		return nil, status.Errorf(codes.NotFound, "path %v is not found in the config structure: %v", fullPath, stat)
+	}
+	var nodeVal interface{}
+	nodeStruct, ok := emptyNode.(ygot.ValidatedGoStruct)
+	if ok {
+		if err := srv.model.jsonUnmarshaler(val.GetJsonIetfVal(), nodeStruct); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "unmarshaling json data to config struct fails: %v", err)
+		}
+		if err := nodeStruct.Validate(); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "config data validation fails: %v", err)
+		}
+		var err error
+		if nodeVal, err = ygot.ConstructIETFJSON(nodeStruct, &ygot.RFC7951JSONConfig{}); err != nil {
+			msg := fmt.Sprintf("error in constructing IETF JSON tree from config struct: %v", err)
+			fmt.Errorf(msg)
+			return nil, status.Error(codes.Internal, msg)
+		}
+	} else {
+		var err error
+		if nodeVal, err = value.ToScalar(val); err != nil {
+			return nil, status.Errorf(codes.Internal, "cannot convert leaf node to scalar type: %v", err)
+		}
+	}
+
+	// Update json tree of the device config.
+	var curNode interface{} = jsonTree
+	schema := srv.model.schemaTreeRoot
+	for i, elem := range fullPath.Elem {
+		switch node := curNode.(type) {
+		case map[string]interface{}:
+			// Set node value.
+			if i == len(fullPath.Elem)-1 {
+				if elem.GetKey() == nil {
+					if grpcStatusError := setPathWithoutAttribute(op, node, elem, nodeVal); grpcStatusError != nil {
+						return nil, grpcStatusError
+					}
+					break
+				}
+				if grpcStatusError := setPathWithAttribute(op, node, elem, nodeVal); grpcStatusError != nil {
+					return nil, grpcStatusError
+				}
+				break
+			}
+
+			if curNode, schema = getChildNode(node, schema, elem, true); curNode == nil {
+				return nil, status.Errorf(codes.NotFound, "path elem not found: %v", elem)
+			}
+		case []interface{}:
+			return nil, status.Errorf(codes.NotFound, "uncompatible path elem: %v", elem)
+		default:
+			return nil, status.Errorf(codes.Internal, "wrong node type: %T", curNode)
+		}
+	}
+	if reflect.DeepEqual(fullPath, pbRootPath) { // Replace/Update root.
+		if op == pb.UpdateResult_UPDATE {
+			return nil, status.Error(codes.Unimplemented, "update the root of config tree is unsupported")
+		}
+		nodeValAsTree, ok := nodeVal.(map[string]interface{})
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "expect a tree to replace the root, got a scalar value: %T", nodeVal)
+		}
+		for k := range jsonTree {
+			delete(jsonTree, k)
+		}
+		for k, v := range nodeValAsTree {
+			jsonTree[k] = v
+		}
+	}
+	newConfig, err := srv.toGoStruct(jsonTree)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	// Apply the validated operation to the device.
+	if srv.callback != nil {
+		if applyErr := srv.callback(newConfig); applyErr != nil {
+			if rollbackErr := srv.callback(srv.config); rollbackErr != nil {
+				return nil, status.Errorf(codes.Internal, "error in rollback the failed operation (%v): %v", applyErr, rollbackErr)
+			}
+			return nil, status.Errorf(codes.Aborted, "error in applying operation to device: %v", applyErr)
+		}
+	}
+	return &pb.UpdateResult{
+		Path: path,
+		Op:   op,
+	}, nil
 }
 
 // Capabilities returns supported encodings and supported models.
@@ -293,9 +562,60 @@ func (srv *Server) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetResponse
 
 }
 
-// Set method is not implemented.
-func (srv *Server) Set(context.Context, *pb.SetRequest) (*pb.SetResponse, error) {
-	return nil, grpc.Errorf(codes.Unimplemented, "Set() is not implemented")
+// Set implements the Set RPC in gNMI spec.
+func (srv *Server) Set(ctx context.Context, req *pb.SetRequest) (*pb.SetResponse, error) {
+	jsonTree, err := ygot.ConstructIETFJSON(srv.config, &ygot.RFC7951JSONConfig{})
+	if err != nil {
+		msg := fmt.Sprintf("error in constructing IETF JSON tree from config struct: %v", err)
+		fmt.Errorf(msg)
+		return nil, status.Error(codes.Internal, msg)
+	}
+
+	prefix := req.GetPrefix()
+	var results []*pb.UpdateResult
+
+	for _, path := range req.GetDelete() {
+		fmt.Printf("Delete path: %v\n", path)
+		res, grpcStatusError := srv.doDelete(jsonTree, prefix, path)
+		if grpcStatusError != nil {
+			return nil, grpcStatusError
+		}
+		results = append(results, res)
+	}
+	for _, upd := range req.GetReplace() {
+		fmt.Printf("Replace path: %v\n", upd.GetPath())
+		res, grpcStatusError := srv.doReplaceOrUpdate(jsonTree, pb.UpdateResult_REPLACE, prefix, upd.GetPath(), upd.GetVal())
+		if grpcStatusError != nil {
+			return nil, grpcStatusError
+		}
+		results = append(results, res)
+	}
+	for _, upd := range req.GetUpdate() {
+		fmt.Printf("Update path: %v\n", upd.GetPath())
+		res, grpcStatusError := srv.doReplaceOrUpdate(jsonTree, pb.UpdateResult_UPDATE, prefix, upd.GetPath(), upd.GetVal())
+		if grpcStatusError != nil {
+			return nil, grpcStatusError
+		}
+		results = append(results, res)
+	}
+
+	jsonDump, err := json.Marshal(jsonTree)
+	if err != nil {
+		msg := fmt.Sprintf("error in marshaling IETF JSON tree to bytes: %v", err)
+		fmt.Errorf(msg)
+		return nil, status.Error(codes.Internal, msg)
+	}
+	rootStruct, err := srv.model.NewConfigStruct(jsonDump)
+	if err != nil {
+		msg := fmt.Sprintf("error in creating config struct from IETF JSON data: %v", err)
+		fmt.Errorf(msg)
+		return nil, status.Error(codes.Internal, msg)
+	}
+	srv.config = rootStruct
+	return &pb.SetResponse{
+		Prefix:   req.GetPrefix(),
+		Response: results,
+	}, nil
 }
 
 // Subscribe method is not implemented.

--- a/pkg/gnmi/util.go
+++ b/pkg/gnmi/util.go
@@ -1,0 +1,102 @@
+package gnmi
+
+import (
+	"fmt"
+	"strconv"
+
+	log "github.com/golang/glog"
+	"github.com/openconfig/goyang/pkg/yang"
+
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// getChildNode gets a node's child with corresponding schema specified by path
+// element. If not found and createIfNotExist is set as true, an empty node is
+// created and returned.
+func getChildNode(node map[string]interface{}, schema *yang.Entry, elem *pb.PathElem, createIfNotExist bool) (interface{}, *yang.Entry) {
+	var nextSchema *yang.Entry
+	var ok bool
+
+	if nextSchema, ok = schema.Dir[elem.Name]; !ok {
+		return nil, nil
+	}
+
+	var nextNode interface{}
+	if elem.GetKey() == nil {
+		if nextNode, ok = node[elem.Name]; !ok {
+			if createIfNotExist {
+				node[elem.Name] = make(map[string]interface{})
+				nextNode = node[elem.Name]
+			}
+		}
+		return nextNode, nextSchema
+	}
+
+	nextNode = getKeyedListEntry(node, elem, createIfNotExist)
+	return nextNode, nextSchema
+}
+
+// getKeyedListEntry finds the keyed list entry in node by the name and key of
+// path elem. If entry is not found and createIfNotExist is true, an empty entry
+// will be created (the list will be created if necessary).
+func getKeyedListEntry(node map[string]interface{}, elem *pb.PathElem, createIfNotExist bool) map[string]interface{} {
+	curNode, ok := node[elem.Name]
+	if !ok {
+		if !createIfNotExist {
+			return nil
+		}
+
+		// Create a keyed list as node child and initialize an entry.
+		m := make(map[string]interface{})
+		for k, v := range elem.Key {
+			m[k] = v
+			if vAsNum, err := strconv.ParseFloat(v, 64); err == nil {
+				m[k] = vAsNum
+			}
+		}
+		node[elem.Name] = []interface{}{m}
+		return m
+	}
+
+	// Search entry in keyed list.
+	keyedList, ok := curNode.([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, n := range keyedList {
+		m, ok := n.(map[string]interface{})
+		if !ok {
+			log.Errorf("wrong keyed list entry type: %T", n)
+			return nil
+		}
+		keyMatching := true
+		// must be exactly match
+		for k, v := range elem.Key {
+			attrVal, ok := m[k]
+			if !ok {
+				return nil
+			}
+			if v != fmt.Sprintf("%v", attrVal) {
+				keyMatching = false
+				break
+			}
+		}
+		if keyMatching {
+			return m
+		}
+	}
+	if !createIfNotExist {
+		return nil
+	}
+
+	// Create an entry in keyed list.
+	m := make(map[string]interface{})
+	for k, v := range elem.Key {
+		m[k] = v
+		if vAsNum, err := strconv.ParseFloat(v, 64); err == nil {
+			m[k] = vAsNum
+		}
+	}
+	node[elem.Name] = append(keyedList, m)
+	return m
+}


### PR DESCRIPTION
Example
- server
```
$ docker run -it --rm -v /etc/oopt:/etc/oopt -p 10164:10164 oopt go run /go/src/github.com/osrg/oopt/gnmi/sample_server/run.go
```
- client
Update frequency channel of Opt6 to 2.
```
$ go run $GOPATH/src/github.com/osrg/oopt/cmd/gnmi_set/gnmi_set.go -target_addr localhost:10164 -update /optical-modules/optical-module[name=Opt6]/optical-module-frequency/config/channel:2
== setRequest:
update: <
  path: <
    elem: <
      name: "optical-modules"
    >
    elem: <
      name: "optical-module"
      key: <
        key: "name"
        value: "Opt6"
      >
    >
    elem: <
      name: "optical-module-frequency"
    >
    elem: <
      name: "config"
    >
    elem: <
      name: "channel"
    >
  >
  val: <
    int_val: 2
  >
>

== getResponse:
response: <
  path: <
    elem: <
      name: "optical-modules"
    >
    elem: <
      name: "optical-module"
      key: <
        key: "name"
        value: "Opt6"
      >
    >
    elem: <
      name: "optical-module-frequency"
    >
    elem: <
      name: "config"
    >
    elem: <
      name: "channel"
    >
  >
  op: UPDATE
>
```